### PR TITLE
Bugfix

### DIFF
--- a/src/store/results/actions.js
+++ b/src/store/results/actions.js
@@ -43,10 +43,15 @@ export const fetchResults = (searchInput) => {
       },
     })
       .then((response) => {
-        console.log(response.data);
+        console.log("Response", response.data);
         // dispatch(setKeyword(searchInput));
-        dispatch(fetchResultsSuccess(response.data.results, searchInput));
-        dispatch(appDoneLoading());
+        if (response.data.results) {
+          dispatch(fetchResultsSuccess(response.data.results, searchInput));
+          dispatch(appDoneLoading());
+        } else {
+          dispatch(showMessageWithTimeout("warning", false, "Word Not Found"));
+          dispatch(appDoneLoading());
+        }
       })
       .catch((error) => {
         console.log(error);


### PR DESCRIPTION
## What this pull request does

- When the words API does not have a result key in the response, the site crashes. 
- Fixed this by checking if the response.result exist then save it in store
- Else show an error message